### PR TITLE
Fix an NRE where Verticies or Elements property could be null

### DIFF
--- a/Assets/SpriteAssist/Editor/Util/TriangulationUtil.cs
+++ b/Assets/SpriteAssist/Editor/Util/TriangulationUtil.cs
@@ -1,4 +1,5 @@
 ﻿using LibTessDotNet;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -35,8 +36,8 @@ namespace SpriteAssist
 
             WindingRule windingRule = nonzero ? WindingRule.NonZero : WindingRule.EvenOdd;
             tess.Tessellate(windingRule);
-            vertices = tess.Vertices.Select(v => new Vector2(v.Position.X, v.Position.Y)).ToArray();
-            triangles = tess.Elements.Select(t => (ushort)t).ToArray();
+            vertices = (tess.Vertices ?? Array.Empty<ContourVertex>()).Select(v => new Vector2(v.Position.X, v.Position.Y)).ToArray();
+            triangles = (tess.Elements ?? Array.Empty<int>()).Select(t => (ushort)t).ToArray();
         }
     }
 }


### PR DESCRIPTION
This NRE could happen if setting the alpha tolerance higher than the entire image. 