### PR TITLE
Add files for Unity Package Manager support

### DIFF
--- a/Assets/SpriteAssist/Editor/Unity-SpriteAssist.asmdef
+++ b/Assets/SpriteAssist/Editor/Unity-SpriteAssist.asmdef
@@ -1,0 +1,9 @@
+{
+    "name": "Unity-SpriteAssist",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": []
+}

--- a/Assets/SpriteAssist/Editor/Unity-SpriteAssist.asmdef.meta
+++ b/Assets/SpriteAssist/Editor/Unity-SpriteAssist.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77865801531f14e69bcbdaf9648b0804
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteAssist/package.json
+++ b/Assets/SpriteAssist/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "com.sr4dev.unity-spriteassist",
+  "displayName": "Unity-SpriteAssist",
+  "version": "0.5.2",
+  "unity": "2019.4",
+  "description": "Unity-SpriteAssist is an Unity extension that assist Sprite's mesh creation more conviniently.",
+  "author": {
+    "name": "sr4dev",
+    "url": "https://github.com/sr4dev/Unity-SpriteAssist"
+  }
+}

--- a/Assets/SpriteAssist/package.json.meta
+++ b/Assets/SpriteAssist/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4cd15dcfba68491486103d950427a12
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
People can include this repo as a package in their Unity project like so:
```
https://github.com/heshuimu/Unity-SpriteAssist.git?path=Assets/SpriteAssist
```

The content of package.json is just a placeholder. You can edit it with actual info. 