### PR TITLE
Change Settings path from PreferencesFolder to ProjectFolder

### DIFF
--- a/Assets/SpriteAssist/Editor/Settings/SpriteAssistSettings.cs
+++ b/Assets/SpriteAssist/Editor/Settings/SpriteAssistSettings.cs
@@ -2,7 +2,7 @@
 
 namespace SpriteAssist
 {
-    [FilePath(SETTINGS_PATH, FilePathAttribute.Location.PreferencesFolder)]
+    [FilePath(SETTINGS_PATH, FilePathAttribute.Location.ProjectFolder)]
     public class SpriteAssistSettings : ScriptableSingleton<SpriteAssistSettings>
     {
         private const string SETTINGS_PATH = "Assets/Editor/SpriteAssistSettings.asset";


### PR DESCRIPTION
Fixes an issue where settings would not persist and a warning would show up when selecting the asset in `Assets/Editor`.